### PR TITLE
Add support for validating negative numbers

### DIFF
--- a/classes/PHPixie/Validate/Ruleset.php
+++ b/classes/PHPixie/Validate/Ruleset.php
@@ -54,13 +54,23 @@ class Ruleset {
 	}
 
 	/**
-	 * Checks if the value consists of numbers only
+	 * Checks if the value consists of numbers only, allowing negative numbers
 	 *
 	 * @param   string  $val  Value to check
 	 * @return  bool 
 	 */
 	public function rule_numeric($val) {
 		return (bool)preg_match('#^[0-9]*$#',$val);
+	}
+	
+	/**
+	 * Checks if the value consists of numbers only
+	 *
+	 * @param   string  $val  Value to check
+	 * @return  bool 
+	 */
+	public function rule_numeric_neg($val) {
+		return (bool)preg_match('#^(-)?[0-9]*$#',$val);
 	}
 	
 	/**
@@ -93,6 +103,16 @@ class Ruleset {
 		return (bool) preg_match('/^[0-9]+(?:\.[0-9]+)?$/D', $val);
 	}
 	
+	/**
+	 * Checks if the value is a decimal number, allowing negative numbers
+	 *
+	 * @param   string  $val  Value to check
+	 * @return  bool 
+	 */
+	public function rule_decimal_neg($val) {
+		return (bool) preg_match('/^(-)?[0-9]+(?:\.[0-9]+)?$/D', $val);
+	}
+
 	
 	/**
 	 * Checks if the value is a phone number

--- a/tests/validate/rulesetTest.php
+++ b/tests/validate/rulesetTest.php
@@ -38,6 +38,18 @@ class RulesetTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
+     * @covers PHPixie\Validate::numeric_neg
+     * @todo   Implement testNumeric_neg().
+     */
+    public function testRule_Numeric_neg()
+    {
+        $this->assertEquals(true, $this->ruleset->rule_numeric_neg(1111));
+	$this->assertEquals(false,$this->ruleset->rule_numeric_neg('a1'));
+        $this->assertEquals(true, $this->ruleset->rule_numeric_neg(-1111));
+	$this->assertEquals(false,$this->ruleset->rule_numeric_neg('-a1'));
+    }
+
+    /**
      * @covers PHPixie\Validate::alpha_numeric
      * @todo   Implement testAlpha_numeric().
      */
@@ -65,6 +77,20 @@ class RulesetTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(true, $this->ruleset->rule_decimal(3));
 		$this->assertEquals(true, $this->ruleset->rule_decimal(3.5));
 		$this->assertEquals(false,$this->ruleset->rule_decimal('3a'));
+    }
+	
+    /**
+     * @covers PHPixie\Validate::decimal_neg
+     * @todo   Implement testDecimal_neg().
+     */
+    public function testRule_Decimal_neg()
+    {
+        $this->assertEquals(true, $this->ruleset->rule_decimal(3));
+	$this->assertEquals(true, $this->ruleset->rule_decimal(3.5));
+	$this->assertEquals(false,$this->ruleset->rule_decimal('3a'));
+        $this->assertEquals(true, $this->ruleset->rule_decimal(-3));
+	$this->assertEquals(true, $this->ruleset->rule_decimal(-3.5));
+	$this->assertEquals(false,$this->ruleset->rule_decimal('-3a'));
     }
 
     /**

--- a/tests/validate/rulesetTest.php
+++ b/tests/validate/rulesetTest.php
@@ -85,12 +85,12 @@ class RulesetTest extends PHPUnit_Framework_TestCase {
      */
     public function testRule_Decimal_neg()
     {
-        $this->assertEquals(true, $this->ruleset->rule_decimal(3));
-	$this->assertEquals(true, $this->ruleset->rule_decimal(3.5));
-	$this->assertEquals(false,$this->ruleset->rule_decimal('3a'));
-        $this->assertEquals(true, $this->ruleset->rule_decimal(-3));
-	$this->assertEquals(true, $this->ruleset->rule_decimal(-3.5));
-	$this->assertEquals(false,$this->ruleset->rule_decimal('-3a'));
+        $this->assertEquals(true, $this->ruleset->rule_decimal_neg(3));
+	$this->assertEquals(true, $this->ruleset->rule_decimal_neg(3.5));
+	$this->assertEquals(false,$this->ruleset->rule_decimal_neg('3a'));
+        $this->assertEquals(true, $this->ruleset->rule_decimal_neg(-3));
+	$this->assertEquals(true, $this->ruleset->rule_decimal_neg(-3.5));
+	$this->assertEquals(false,$this->ruleset->rule_decimal_neg('-3a'));
     }
 
     /**


### PR DESCRIPTION
Current rules "numeric" and "decimal" only validates positive numbers.
Added two new rules "numeric_neg" and "decimal_neg" that also allows negative numbers to successfully validate. 
Added the unit tests for these rules.
I think the docs should be updated to reflect that numeric and decimal rules works for zero and positive numbers only.